### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ JOROOT="/Users/rasmus/src2/jo"
 
 ## Automatic package-internal vs exported symbols
 
-Like Go, Jo automatically exports symbols that begin with a captial letter:
+Like Go, Jo automatically exports symbols that begin with a capital letter:
 
 foo/info.js
 ```js


### PR DESCRIPTION
@rsms, I've corrected a typographical error in the documentation of the [jo](https://github.com/rsms/jo) project. Specifically, I've changed captial to capital. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
